### PR TITLE
Fix Input and label StyledComponents relation for referencing

### DIFF
--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -2,9 +2,9 @@ import React from 'react'
 
 import * as S from './styled'
 
-function Input( { placeholder} ){
+function Input( { placeholder, ...props } ){
   return (
-    <S.Input placeholder={placeholder} />
+    <S.Input placeholder={placeholder} {...props} />
   )
 }
 


### PR DESCRIPTION
If you're not altering the `placeholder` prop, you might as well refactor this to:

```javascript
function Input(props){
  return <S.Input {...props} />
}
```